### PR TITLE
minor fixes to top-level build

### DIFF
--- a/git-clone-repos
+++ b/git-clone-repos
@@ -15,7 +15,11 @@ while read repo; do
         if [ -d $repo ]; then
             echo "Directory $repo already exists"
         else
-            git clone --recurse-submodules https://github.com/draperlaboratory/hope-$repo $repo
+            if [[ $repo = freedom-e-sdk ]]; then
+                git clone https://github.com/draperlaboratory/hope-$repo $repo
+            else
+                git clone --recurse-submodules https://github.com/draperlaboratory/hope-$repo $repo
+            fi
         fi
     fi
 done < $repo_file

--- a/repos.txt
+++ b/repos.txt
@@ -9,3 +9,4 @@ renode-plugins
 freedom-e-sdk
 riscv-newlib
 llvm-riscv
+qemu


### PR DESCRIPTION
Two small build system changes:

1) Add qemu to repos list so it gets pulled by git-clone-repos.  Other things in the makefile depend on it.

2) Add a special case to git-clone-repos so it doesn't pull the submodules of freedom-e-sdk.  These submodules aren't needed, and cause an error inside Draper because of a git:// url in a submodule of a submodule.