### PR TITLE
Switch to official LLVM git monorepo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ PROJECTS += renode-plugins
 PROJECTS += renode
 PROJECTS += freedom-e-sdk
 PROJECTS += riscv-newlib
-PROJECTS += llvm-riscv
+PROJECTS += llvm-project
 PROJECTS += qemu
 
 CLEAN_PROJECTS := $(patsubst %,clean-%,$(PROJECTS))
@@ -35,9 +35,9 @@ all: path_check runtime
 
 policy-engine: policy-tool
 renode-plugins: renode
-llvm-riscv: riscv-gnu-toolchain
+llvm-project: riscv-gnu-toolchain
 qemu: policy-engine
-riscv-newlib: llvm-riscv
+riscv-newlib: llvm-project
 
 path_check:
 	(grep -q $(ISP_PREFIX)bin <<< $(PATH)) || (echo "Need to add $(ISP_PREFIX)/bin to your PATH" && false)

--- a/repos.txt
+++ b/repos.txt
@@ -8,5 +8,5 @@ policy-engine
 renode-plugins
 freedom-e-sdk
 riscv-newlib
-llvm-riscv
+llvm-project
 qemu


### PR DESCRIPTION
LLVM has migrated to a single git "monorepo" that encompasses all LLVM projects. They plan to retire the various unofficial git-svn repo mirrors that we are currently using.

We could hold off on migrating for a bit, but I would prefer to switch now as it will simplify the process of merging from upstream LLVM.

The build process is also a bit more streamlined in the new regime.