### PR TITLE
Fix PATH issues during install

### DIFF
--- a/isp-support/install-dependencies-ubuntu1804
+++ b/isp-support/install-dependencies-ubuntu1804
@@ -21,4 +21,4 @@ sudo apt-get install -y autoconf automake autogen autotools-dev curl \
     python3-psutil xterm verilator virtualenv python3-pip
 
 sudo pip3 install pyinstaller
-stack upgrade --binary-only --allow-different-user
+sudo stack upgrade --binary-only --allow-different-user --local-bin-path /usr/bin

--- a/isp-support/set-env
+++ b/isp-support/set-env
@@ -4,4 +4,4 @@
 
 export ISP_PREFIX=$ISP
 [[ ":$PATH:" != *":${ISP_PREFIX}bin:"* ]] && \
-  export PATH="${ISP_PREFIX}bin:${PATH}"
+  export PATH="${PATH}:${ISP_PREFIX}bin"


### PR DESCRIPTION
Two changes to the installation process:

- Change the destination path of the upgraded haskell stack executable so that it overwrites the old one. By default the new executable is installed to ~/.local/bin, which is not in the default Ubuntu PATH
- Change the set-env script to append ISP_PREFIX to the PATH instead of prepending it. This fixes issues when rebuilding LLVM which involved using the wrong clang binary.