### PR TITLE
Flatten list of entities when combining policies into one file

### DIFF
--- a/runtime/isp_kernel.py
+++ b/runtime/isp_kernel.py
@@ -55,11 +55,12 @@ def copyPolicyYaml(policy, policies_dir, entities_dir, output_dir):
                 if os.path.isfile(os.path.join(entities_dir, policy_entities_file)):
                     f = os.path.join(entities_dir, policy_entities_file)
                     with open(f, "r") as instream:
-                        for e in yaml.load_all(instream, Loader=yaml.FullLoader):
-                            ents.append(e)
+                        for el in yaml.load_all(instream, Loader=yaml.FullLoader):
+                            for e in el:
+                                ents.append(e)
 
             if ents:
-                yaml.dump_all(ents, comp_ents)
+                yaml.dump_all([ents], comp_ents)
 
     if not os.path.isfile(entities_dest):
         shutil.copyfile(os.path.join(entities_dir, "empty.entities.yml"), entities_dest)


### PR DESCRIPTION
Entities were being stored as multiple YAML "documents" within the file. Whatever read the file did not read past the first, so in my multi-policy test, only code tags for the first policy were actually used.

This flattens the list so that the entire entities file is read.