### PR TITLE
Ignore ctrl-c in isp_debug.py

### DIFF
--- a/runtime/isp_debug.py
+++ b/runtime/isp_debug.py
@@ -6,6 +6,7 @@ import os
 import sys
 import time
 import isp_utils
+import signal
 
 gdb_command = "riscv32-unknown-elf-gdb"
 
@@ -22,6 +23,9 @@ def startGdb(exe_path, port, sim):
         args.insert(6, "-ex")
         args.insert(7, "monitor start")
 
+    # Ignore ctrl-c so it's possible to interrupt gdb in a loop
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+        
     proc = subprocess.call(args)
 
 


### PR DESCRIPTION
When using `isp_debug` I found it annoying that python would intercept SIGINT (ctrl-c) when I intended it to be sent to gdb in order to halt execution. This fixes that.