### PR TITLE
Add flag to isp_run_app.py to accept pre-existing tagfiles

### DIFF
--- a/runtime/isp_qemu.py
+++ b/runtime/isp_qemu.py
@@ -121,7 +121,7 @@ def launchQEMUDebug(exe_path, run_dir, policy_dir, gdb_port, extra, runtime, use
 
 
 def runSim(exe_path, run_dir, policy_dir, runtime,
-           gdb_port, soc_cfg, extra, use_validator=True):
+           gdb_port, tagfile, soc_cfg, extra, use_validator=True):
     global run_cmd
     global uart_log_file
     global status_log_file
@@ -131,8 +131,10 @@ def runSim(exe_path, run_dir, policy_dir, runtime,
         run_cmd = os.path.join(os.environ['ISP_PREFIX'],'stock-tools','bin','qemu-system-riscv32')
     else:
         run_cmd = os.path.join(os.environ['ISP_PREFIX'],'bin','qemu-system-riscv32')
-        if isp_utils.generateTagInfo(exe_path, run_dir, policy_dir) is False:
-            return isp_utils.retVals.TAG_FAIL
+
+        if tagfile is None:
+            if isp_utils.generateTagInfo(exe_path, run_dir, policy_dir) is False:
+                return isp_utils.retVals.TAG_FAIL
 
     try:
         logger.debug("Begin QEMU test... (timeout: {})".format(timeout_seconds))

--- a/runtime/isp_run.py
+++ b/runtime/isp_run.py
@@ -53,7 +53,7 @@ def runSim(exe_path, policy_dir, run_dir, sim, runtime, rule_cache, gdb, tag_onl
 
     sim_module = __import__("isp_" + sim)
     ret_val = sim_module.runSim(exe_path, run_dir, policy_dir, runtime,
-                                gdb, soc_cfg, extra, use_validator)
+                                gdb, tagfile, soc_cfg, extra, use_validator)
 
     return ret_val
 

--- a/runtime/isp_run.py
+++ b/runtime/isp_run.py
@@ -31,7 +31,7 @@ logger = logging.getLogger()
 #  tag_only - run the tagging tools without running the simulator
 #  extra - extra command line arguments to the simulator
 
-def runSim(exe_path, policy_dir, run_dir, sim, runtime, rule_cache, gdb, tag_only, soc_cfg, use_validator, extra):
+def runSim(exe_path, policy_dir, run_dir, sim, runtime, rule_cache, gdb, tag_only, tagfile, soc_cfg, use_validator, extra):
     exe_name = os.path.basename(exe_path)
 
     if not os.path.isfile(exe_path):
@@ -45,7 +45,7 @@ def runSim(exe_path, policy_dir, run_dir, sim, runtime, rule_cache, gdb, tag_onl
     doMkDir(run_dir)
 
     if "stock_" not in runtime and use_validator == True:
-        doValidatorCfg(policy_dir, run_dir, exe_name, rule_cache, soc_cfg)
+        doValidatorCfg(policy_dir, run_dir, exe_name, rule_cache, soc_cfg, tagfile)
         doEntitiesFile(run_dir, exe_name)
 
         if tag_only is True:
@@ -79,11 +79,14 @@ def doEntitiesFile(run_dir, name):
         open(filename, "a").close()
 
 
-def doValidatorCfg(policy_dir, run_dir, exe_name, rule_cache, soc_cfg):
+def doValidatorCfg(policy_dir, run_dir, exe_name, rule_cache, soc_cfg, tagfile):
     rule_cache_name = rule_cache[0]
     rule_cache_size = rule_cache[1]
 
     logger.info("Using soc_cfg file: {}".format(soc_cfg))
+
+    if tagfile == None:
+        tagfile = os.path.join(run_dir, "bininfo", exe_name + ".taginfo")
 
     validatorCfg =  """\
 ---
@@ -91,7 +94,7 @@ def doValidatorCfg(policy_dir, run_dir, exe_name, rule_cache, soc_cfg):
    tags_file: {tagfile}
    soc_cfg_path: {soc_cfg}
 """.format(policyDir=policy_dir,
-           tagfile=os.path.join(run_dir, "bininfo", exe_name + ".taginfo"),
+           tagfile=os.path.abspath(tagfile),
            soc_cfg=soc_cfg)
 
     if rule_cache_name != "":

--- a/runtime/isp_run_app.py
+++ b/runtime/isp_run_app.py
@@ -62,6 +62,9 @@ def main():
     parser.add_argument("-t", "--tag-only", action="store_true", help='''
     Run the tagging tools without running the application
     ''')
+    parser.add_argument("-T", "--tagfile", default=None, help='''
+    Path of tag file to use rather than generating it based on policy
+    ''')
     parser.add_argument("-C", "--rule-cache-name", type=str, default="", help='''
     Name of the rule cache
     ''')
@@ -127,6 +130,7 @@ def main():
     exe_full_path = os.path.abspath(args.exe_path)
     run_dir = os.path.join(output_dir,
                            "isp-run-{}-{}".format(exe_name, policy_name))
+
     if args.rule_cache_name != "":
         run_dir = run_dir + "-{}-{}".format(args.rule_cache_name,
                                             args.rule_cache_size)
@@ -154,6 +158,7 @@ def main():
                             (args.rule_cache_name, args.rule_cache_size),
                             args.gdb,
                             args.tag_only,
+                            args.tagfile,
                             soc_path,
                             use_validator,
                             args.extra)


### PR DESCRIPTION
We propose a new flag, `-T` / `--tagfile` (name subject to bikeshed) which
allows the user to specify a specific tag file, such as the output of
`gen_tag_info`. Then, when generating the `$run_dir/validator_cfg.yml`, this
filename is used for the `tags_file` key instead of the path that would've been
created by `gen_tag_info`. In addition, we avoid running `gen_tag_info` in the
case this flag is specified, since it is unnecessary and the artifacts it
produces might be confusing.

This is motivated by our desire to tag files based on binary analysis.