### PR TITLE
Remove obsolete pyinstaller dependency

### DIFF
--- a/isp-support/install-dependencies-ubuntu1804
+++ b/isp-support/install-dependencies-ubuntu1804
@@ -12,5 +12,4 @@ sudo apt-get install -y autoconf automake autogen autotools-dev curl \
     libyaml-cpp-dev libgflags-dev \
     python3-psutil xterm verilator virtualenv python3-pip
 
-sudo pip3 install pyinstaller
 sudo stack upgrade --binary-only --allow-different-user --local-bin-path /usr/bin


### PR DESCRIPTION
The pyinstaller dependency is obsolete and should be removed. Currently, it may disrupt the setup process, since pip requires `sudo -H` on some systems.