### PR TITLE
Fixes for running 64-bit Hardware

### DIFF
--- a/runtime/isp_utils.py
+++ b/runtime/isp_utils.py
@@ -119,7 +119,7 @@ def terminateMessage(runtime):
     if runtime == "sel4":
         return "seL4 root server abort()ed"
     elif runtime == "bare":
-        return "Program has exited with code:"
+        return "Program exited with code:"
 
     return ""
 

--- a/runtime/modules/isp_vcs.py
+++ b/runtime/modules/isp_vcs.py
@@ -211,6 +211,9 @@ def runSim(exe_path, run_dir, policy_dir, pex_path, runtime, rule_cache,
     pex_hex_dump_path = os.path.join(run_dir, os.path.basename(pex_load_image_path) + ".hex")
     policy_name = os.path.basename(policy_dir)
 
+    if not soc_cfg:
+        soc_cfg = os.path.join(isp_prefix, "soc_cfg", "gfe-vcu118.yml")
+
     if isp_utils.generateTagInfo(exe_path, run_dir, policy_dir, soc_cfg=soc_cfg, arch=arch) is False:
         return isp_utils.retVals.TAG_FAIL
 

--- a/runtime/modules/isp_vcs.py
+++ b/runtime/modules/isp_vcs.py
@@ -47,6 +47,7 @@ def installTagMemHexdump(policy_name, output_dir):
                              cwd=pex_kernel_output_dir, env=env)
 
     if result != 0:
+        logger.error("Failed to install tag_mem_hexdump")
         return False
 
     return True

--- a/runtime/modules/isp_vcu118.py
+++ b/runtime/modules/isp_vcu118.py
@@ -157,8 +157,9 @@ def start_openocd(log_file=None):
     return openocd_proc
 
 
-def gdb_thread(exe_path, log_file=None):
-    child = pexpect.spawn("riscv32-unknown-elf-gdb", [exe_path], encoding="utf-8", timeout=None)
+def gdb_thread(exe_path, log_file=None, arch="rv32"):
+    xlen = 64 if arch == "rv64" else 32
+    child = pexpect.spawn("riscv{}-unknown-elf-gdb".format(xlen), [exe_path], encoding="utf-8", timeout=None)
     if log_file is None:
         child.logfile = sys.stdout
     else:
@@ -225,7 +226,7 @@ def tagInit(exe_path, run_dir, policy_dir, soc_cfg, arch, pex_kernel_path,
 
 
 def runPipe(exe_path, ap, pex_tty, pex_log, openocd_log_file,
-            gdb_log_file, flash_init_image_path, gdb_port, no_log):
+            gdb_log_file, flash_init_image_path, gdb_port, no_log, arch):
     logger.debug("Connecting to {}".format(pex_tty))
     pex_serial = serial.Serial(pex_tty, 115200, timeout=3000000,
             bytesize=serial.EIGHTBITS, parity=serial.PARITY_NONE, xonxoff=False, rtscts=False, dsrdtr=False)
@@ -235,6 +236,7 @@ def runPipe(exe_path, ap, pex_tty, pex_log, openocd_log_file,
     
     logger.info("Sending flash init file {} to {}".format(flash_init_image_path, pex_tty))
     pex_serial.write(open(flash_init_image_path, "rb").read())
+    logger.debug("Done writing init file")
 
     pex_expect.expect("Entering idle loop.")
     pex_expect.close()
@@ -249,7 +251,7 @@ def runPipe(exe_path, ap, pex_tty, pex_log, openocd_log_file,
         return isp_utils.retVals.FAILURE
 
     logger.debug("Spawning gdb")
-    gdb = multiprocessing.Process(target=gdb_thread, args=(exe_path, gdb_log_file))
+    gdb = multiprocessing.Process(target=gdb_thread, args=(exe_path, gdb_log_file, arch))
 
     if gdb_port == 0:
         gdb.start()
@@ -259,6 +261,7 @@ def runPipe(exe_path, ap, pex_tty, pex_log, openocd_log_file,
         while True:
             pass
 
+    logger.debug("waiting for pex and ap to finish")
     while pex.is_alive() and ap.is_alive():
         pass
 
@@ -279,7 +282,7 @@ def runStock(exe_path, ap, openocd_log_file, gdb_log_file,
         return isp_utils.retVals.FAILURE
 
     logger.debug("Spawning gdb")
-    gdb = threading.Thread(target=gdb_thread, args=(exe_path, gdb_log_file))
+    gdb = threading.Thread(target=gdb_thread, args=(exe_path, gdb_log_file, arch))
     if gdb_port == 0:
         gdb.start()
 
@@ -358,7 +361,7 @@ def runSim(exe_path, run_dir, policy_dir, pex_path, runtime, rule_cache,
         result = runStock(exe_path, ap, openocd_log_file, gdb_log_file, gdb_port, extra_args.no_log)
     else:
         result = runPipe(exe_path, ap, pex_tty, pex_log, openocd_log_file,
-                         gdb_log_file, flash_init_image_path, gdb_port, extra_args.no_log)
+                         gdb_log_file, flash_init_image_path, gdb_port, extra_args.no_log, arch)
 
     pex_log.close()
     ap_log.close()

--- a/runtime/modules/isp_vcu118.py
+++ b/runtime/modules/isp_vcu118.py
@@ -114,7 +114,7 @@ def detectTTY(symlink):
 
 def program_fpga(bit_file, ltx_file, log_file):
     tcl_script = os.path.join(isp_prefix, "vcu118", "tcl", "prog_bit.tcl")
-    args = ["vivado", "-mode", "batch", "-source", tcl_script, "-tclargs", bit_file, ltx_file]
+    args = ["vivado", "-mode", "batch", "-source", tcl_script, "-tclargs", bit_file, ltx_file, "vcu118"]
 
     if not isp_utils.checkDependency(tcl_script, logger, "hope-gfe"):
         return False

--- a/runtime/templates/vcu118/isp_utils.c
+++ b/runtime/templates/vcu118/isp_utils.c
@@ -32,7 +32,13 @@ void isp_test_device_fail(void)
 uint64_t isp_get_cycle_count(uint32_t *result_hi, uint32_t *result_lo)
 {
 #if __riscv_xlen == 64
-	return read_csr(mcycle);
+	uint64_t cycle;
+	asm volatile(
+		"%=:\n\t"
+		"csrr %0, mcycle\n\t"
+		: "=r"(cycle));
+
+  return cycle;
 #else
 	uint32_t cycle_lo, cycle_hi;
 	asm volatile(


### PR DESCRIPTION
Use `riscv64-unknown-elf-gdb` to execute code on a 64-bit AP and fix the AP UART message that is expected by the runtime to know if the test is complete.