### PR TITLE
Set UART baud rate to be 115200 all the time

### DIFF
--- a/runtime/modules/isp_vcu118.py
+++ b/runtime/modules/isp_vcu118.py
@@ -290,7 +290,7 @@ def runPipe(exe_path, ap, pex_tty, pex_log, openocd_log_file,
 
 
 def runStock(exe_path, ap, openocd_log_file, gdb_log_file,
-             gdb_port, no_log):
+             gdb_port, no_log, arch):
     logger.debug("Spawning openocd")
     openocd_proc = start_openocd(openocd_log_file)
     if not openocd_proc:
@@ -373,7 +373,7 @@ def runSim(exe_path, run_dir, policy_dir, pex_path, runtime, rule_cache,
         ap.start()
 
     if extra_args.stock:
-        result = runStock(exe_path, ap, openocd_log_file, gdb_log_file, gdb_port, extra_args.no_log)
+        result = runStock(exe_path, ap, openocd_log_file, gdb_log_file, gdb_port, extra_args.no_log, arch)
     else:
         result = runPipe(exe_path, ap, pex_tty, pex_log, openocd_log_file,
                          gdb_log_file, flash_init_image_path, gdb_port, extra_args.no_log, arch)

--- a/runtime/modules/isp_vcu118.py
+++ b/runtime/modules/isp_vcu118.py
@@ -191,12 +191,7 @@ def gdb_thread(exe_path, log_file=None, arch="rv32"):
 
 
 def ap_thread(ap_tty, ap_log, runtime, processor):
-    baud_rate = 0
-
-    if processor == "P1":
-        baud_rate = 57600
-    elif processor == "P2":
-        baud_rate = 115200
+    baud_rate = 115200
 
     ap_serial = serial.Serial(ap_tty, baud_rate, timeout=3000000, bytesize=serial.EIGHTBITS,
                                parity=serial.PARITY_NONE, xonxoff=False, rtscts=False, dsrdtr=False)


### PR DESCRIPTION
With draperlaboratory/hope-freedom-e-sdk#24, the AP UART thread for vcu118 can be configured with a baud rate of 115200 for both P1 and P2.