### PR TITLE
Fixes to VCU118 and VCS modules

### DIFF
--- a/runtime/isp_load_image.py
+++ b/runtime/isp_load_image.py
@@ -115,6 +115,28 @@ def generate_load_image(elf_binary, output_image, tag_info=None):
                                     taginfo_offset,
                                     len(taginfo_bytes)))
 
+def generate_tag_load_image(output_image, tag_info):
+    with open(output_image, 'wb') as out:
+        out.write(load_image_t.pack(0xD04EA001,
+                                    0xffffffff,
+                                    0xffffffff,
+                                    0xffffffff,
+                                    0xffffffff))
+
+        taginfo_offset = out.tell()
+        taginfo_bytes = Path(tag_info).read_bytes()
+        out.write(taginfo_bytes)
+        if (len(taginfo_bytes) & 3 != 0):
+            pad = bytearray(4 - (len(taginfo_bytes) & 3))
+            out.write(pad)
+
+        out.seek(0)
+        out.write(load_image_t.pack(0xD04EA001,
+                                    0xffffffff,
+                                    0xffffffff,
+                                    taginfo_offset,
+                                    len(taginfo_bytes)))
+
 
 def generate_flash_init(output_image, input_images):
     out = open(output_image, 'wb')

--- a/runtime/modules/isp_vcs.py
+++ b/runtime/modules/isp_vcs.py
@@ -98,7 +98,6 @@ def parseExtra(extra):
     parser.add_argument("--debug", action="store_true", help="Enable debug tracing")
     parser.add_argument("--timeout", type=int, default=0, help="Simulator timeout (in seconds)")
     parser.add_argument("--max-cycles", type=int, default=300000000, help="Maxmimum number of cycles to simulate")
-    parser.add_argument("--init-only", action="store_true", help="Generate artifacts without running the simulator")
     parser.add_argument("--processor", type=str, default="P1", help="GFE processor configuration (P1/P2/P3)")
 
     if extra is not None:
@@ -204,7 +203,7 @@ def runVcsSim(exe_path, ap_hex_dump_path, pex_hex_dump_path, tag_mem_hexdump_pat
 
 
 def runSim(exe_path, run_dir, policy_dir, pex_path, runtime, rule_cache,
-           gdb_port, tagfile, soc_cfg, arch, extra, use_validator=False):
+           gdb_port, tagfile, soc_cfg, arch, extra, use_validator=False, tag_only=False):
     extra_args = parseExtra(extra)
     ap_log_file = os.path.join(run_dir, "uart.log")
     pex_log_file = os.path.join(run_dir, "pex.log")
@@ -229,7 +228,7 @@ def runSim(exe_path, run_dir, policy_dir, pex_path, runtime, rule_cache,
     isp_load_image.generate_hex_dump(ap_load_image_path, ap_hex_dump_path, 64)
     isp_load_image.generate_hex_dump(pex_load_image_path, pex_hex_dump_path, 64)
 
-    if extra_args.init_only is True:
+    if tag_only is True:
         return isp_utils.retVals.SUCCESS
 
     # XXX: use default logfile names for now, update for parallel sim runs

--- a/runtime/modules/isp_vcu118.py
+++ b/runtime/modules/isp_vcu118.py
@@ -85,7 +85,6 @@ def parseExtra(extra):
     parser.add_argument("--ap-address", type=str, default="0xf8040000", help='''
     Hex address (0x format) for the application processor load image in the flash init.
     ''')
-    parser.add_argument("--init-only", action="store_true", help="Generate the flash init without running on the FPGA")
     parser.add_argument("--bitstream", type=str,
                         help="Re-program the FPGA with the specified bitstream")
     parser.add_argument("--processor", type=str, default="P1", help="GFE processor configuration (P1/P2/P3)")
@@ -316,7 +315,7 @@ def runStock(exe_path, ap, openocd_log_file, gdb_log_file,
 
 
 def runSim(exe_path, run_dir, policy_dir, pex_path, runtime, rule_cache,
-           gdb_port, tagfile, soc_cfg, arch, extra, use_validator=False):
+           gdb_port, tagfile, soc_cfg, arch, extra, use_validator=False, tag_only=False):
     extra_args = parseExtra(extra)
     ap_log_file = os.path.join(run_dir, "uart.log")
     pex_log_file = os.path.join(run_dir, "pex.log")
@@ -340,7 +339,7 @@ def runSim(exe_path, run_dir, policy_dir, pex_path, runtime, rule_cache,
                        extra_args.kernel_address, extra_args.ap_address):
             return isp_utils.retVals.TAG_FAIL
 
-    if extra_args.init_only:
+    if tag_only:
         return isp_utils.retVals.SUCCESS
 
     ap_log = open(ap_log_file, "w")

--- a/runtime/modules/isp_vcu118.py
+++ b/runtime/modules/isp_vcu118.py
@@ -226,7 +226,7 @@ def tagInit(exe_path, run_dir, policy_dir, soc_cfg, arch, pex_kernel_path,
     logger.debug("Using flash init file {}".format(flash_init_image_path))
     if not os.path.exists(flash_init_image_path):
         logger.info("Generating flash init")
-        isp_load_image.generate_load_image(exe_path, ap_load_image_path, tag_file_path)
+        isp_load_image.generate_tag_load_image(ap_load_image_path, tag_file_path)
         isp_load_image.generate_load_image(pex_kernel_path, pex_load_image_path)
 
         flash_init_map = {kernel_address:pex_load_image_path,


### PR DESCRIPTION
- Adds tag_only argument to the isp_vcu118 and isp_vcs modules

- Stops isp_vcu118 from redundantly loading the AP ELF into PEX flash memory