### PR TITLE
FPGA test changes

### DIFF
--- a/runtime/isp_run_app.py
+++ b/runtime/isp_run_app.py
@@ -272,7 +272,7 @@ def main():
 
     if result != isp_utils.retVals.SUCCESS:
         logger.error(result)
-        sys.exit(-1)
+        os._exit(-1)
 
     if args.tag_only is True:
         return

--- a/runtime/modules/isp_vcu118.py
+++ b/runtime/modules/isp_vcu118.py
@@ -166,8 +166,7 @@ def start_openocd(log_file=None):
 
 
 def gdb_thread(exe_path, log_file=None, arch="rv32"):
-    xlen = 64 if arch == "rv64" else 32
-    child = pexpect.spawn("riscv{}-unknown-elf-gdb".format(xlen), [exe_path], encoding="utf-8", timeout=None)
+    child = pexpect.spawn("riscv64-unknown-elf-gdb", [exe_path], encoding="utf-8", timeout=None)
     if log_file is None:
         child.logfile = sys.stdout
     else:

--- a/runtime/modules/isp_vcu118.py
+++ b/runtime/modules/isp_vcu118.py
@@ -247,7 +247,10 @@ def runPipe(exe_path, ap, pex_tty, pex_log, openocd_log_file,
     pex_serial.write(open(flash_init_image_path, "rb").read())
     logger.debug("Done writing init file")
 
-    pex_expect.expect("Entering idle loop.")
+    found = pex_expect.expect(["Entering idle loop.", "Entering infinite loop.", pexpect.EOF])
+    if found > 0:
+        pex_expect.close()
+        return isp_utils.retVals.FAILURE
     pex_expect.close()
 
     pex = multiprocessing.Process(target=pex_thread, args=(pex_tty, pex_log))

--- a/runtime/templates/vcu118/isp_utils.c
+++ b/runtime/templates/vcu118/isp_utils.c
@@ -40,16 +40,19 @@ uint64_t isp_get_cycle_count(uint32_t *result_hi, uint32_t *result_lo)
 
   return cycle;
 #else
-	uint32_t cycle_lo, cycle_hi;
-	asm volatile(
-		"%=:\n\t"
-		"csrr %1, mcycleh\n\t"
-		"csrr %0, mcycle\n\t"
-		"csrr t1, mcycleh\n\t"
-		"bne  %1, t1, %=b"
-		: "=r"(cycle_lo), "=r"(cycle_hi)
-		: // No inputs.
-		: "t1");
+	uint32_t cycle_lo, cycle_hi, temp_hi;
+        // Loop outside of the inline assembly to avoid issues with LLVM
+        // policies that don't tag inline assembly
+        do {
+            asm volatile(
+                    "csrr %1, mcycleh\n\t"
+                    "csrr %0, mcycle\n\t"
+                    "csrr %2, mcycleh\n\t"
+                    : "=r"(cycle_lo), "=r"(cycle_hi), "=r" (temp_hi)
+                    : // No inputs.
+                    : // No temps
+                    );
+        } while (temp_hi != cycle_hi);
 
    // XXX: pass back hi/lo to get around unreliable 64-bit intrinsics
    if(result_hi != NULL) {


### PR DESCRIPTION
This fixes LLVM policies on the FPGA and to shorten the time taken when tests error.