### PR TITLE
Fix bug with stripping the "-debug" off policy name

### DIFF
--- a/runtime/modules/isp_vcs.py
+++ b/runtime/modules/isp_vcs.py
@@ -112,9 +112,9 @@ def parseExtra(extra):
         return parser.parse_args(extra_dashed)
     return parser.parse_args([])
 
-
+dbg_suffix = "-debug"
 def generateTagMemHexdump(tag_file_path, policy):
-    policy = policy.strip("-debug")
+    policy = policy if not policy.endswith(dbg_suffix) else policy[:-len(dbg_suffix)]
     output_path = tag_file_path + ".hex"
     subprocess.call(["tag_mem_hexdump-" + policy, tag_file_path, output_path])
     return output_path

--- a/runtime/modules/isp_vcs.py
+++ b/runtime/modules/isp_vcs.py
@@ -112,9 +112,9 @@ def parseExtra(extra):
         return parser.parse_args(extra_dashed)
     return parser.parse_args([])
 
-dbg_suffix = "-debug"
+debug_suffix = "-debug"
 def generateTagMemHexdump(tag_file_path, policy):
-    policy = policy if not policy.endswith(dbg_suffix) else policy[:-len(dbg_suffix)]
+    policy = policy if not policy.endswith(debug_suffix) else policy[:-len(debug_suffix)]
     output_path = tag_file_path + ".hex"
     subprocess.call(["tag_mem_hexdump-" + policy, tag_file_path, output_path])
     return output_path


### PR DESCRIPTION
In python, the `.strip()` function strips trailing characters matching anything in the argument, so `"none-debug".strip("-debug")` results in `"non"`.  This fixes that by first checking if the policy name ends in `"-debug"` and then just removing the last six characters if it does.