### PR TITLE
SBRK Wrapper

### DIFF
--- a/runtime/modules/isp_vcu118.py
+++ b/runtime/modules/isp_vcu118.py
@@ -166,8 +166,7 @@ def start_openocd(log_file=None):
 
 
 def gdb_thread(exe_path, log_file=None, arch="rv32"):
-    xlen = 64 if arch == "rv64" else 32
-    child = pexpect.spawn("riscv{}-unknown-elf-gdb".format(xlen), [exe_path], encoding="utf-8", timeout=None)
+    child = pexpect.spawn("riscv64-unknown-elf-gdb", [exe_path], encoding="utf-8", timeout=None)
     if log_file is None:
         child.logfile = sys.stdout
     else:

--- a/runtime/templates/vcu118/bare.mk
+++ b/runtime/templates/vcu118/bare.mk
@@ -56,6 +56,7 @@ ISP_LDFLAGS      += -Wl,--wrap=read
 ISP_LDFLAGS      += -Wl,--wrap=write
 ISP_LDFLAGS      += -Wl,--wrap=malloc
 ISP_LDFLAGS      += -Wl,--wrap=free
+ISP_LDFLAGS		 += -Wl,--wrap=sbrk -Wl,--wrap=_sbrk
 ISP_LDFLAGS 		 += -Wl,--undefined=pvPortMalloc
 ISP_LDFLAGS      += -Wl,--undefined=pvPortFree
 


### PR DESCRIPTION
Use the `sbrk` wrapper in the "sbrk" branch of freedom-e-sdk.