### PR TITLE
Sort segments before iterating through them

### DIFF
--- a/runtime/isp_load_image.py
+++ b/runtime/isp_load_image.py
@@ -62,7 +62,7 @@ def generate_load_image(elf_binary, output_image, tag_info=None):
             open_segment = None
             elision = None
             elision_dict = {}
-            for s in ef.iter_sections():
+            for s in sorted(ef.iter_sections(), key=lambda s: s["sh_addr"]):
                 if include_section(s):
                     logger.debug("section {0} at 0x{1:x}, for 0x{2:x} bytes".format(s.name, s["sh_addr"], s["sh_size"]))
                     elision = SectionElision(s)


### PR DESCRIPTION
The extend() function of SegmentElision requires that the segments' start addresses come after preceding segments end addresses.  Not all .elf files do this (as shown by some of the ones produced by freedom-e-sdk), so the sections have to be sorted in address order before processing them.