### PR TITLE
Add rsync

### DIFF
--- a/isp-support/install-dependencies-ubuntu1804
+++ b/isp-support/install-dependencies-ubuntu1804
@@ -12,6 +12,6 @@ sudo apt-get install -y autoconf automake autogen autotools-dev curl \
     libyaml-cpp-dev libgflags-dev \
     python3-psutil xterm verilator virtualenv python3-pip \
     libftdi1-2 libusb-1.0-0-dev libtinfo5 \
-    libglib2.0-dev libpixman-1-dev pkg-config device-tree-compiler
+    libglib2.0-dev libpixman-1-dev pkg-config device-tree-compiler rsync
 
 sudo stack upgrade --binary-only --allow-different-user --local-bin-path /usr/bin


### PR DESCRIPTION
Add rsync to isp dependencies. It's not present on the ubuntu 18.04 docker image.