### PR TITLE
Enable Global Installation

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -32,6 +32,9 @@ MODULE_FILES += isp_iveia.py
 
 MODULES := $(patsubst %,modules/%,$(MODULE_FILES))
 
+SOURCES := pex-kernel
+SOURCES += policies
+
 BARE_PREFIX := osv.bare.main.
 FRTOS_PREFIX := osv.frtos.main.
 SEL4_PREFIX := osv.sel4.main.
@@ -41,10 +44,10 @@ INSTALLED_ISP_SCRIPTS := $(patsubst %,$(BIN_DIR)/%,$(ISP_SCRIPTS))
 PYTHON_SCRIPTS := $(patsubst %,%.py,$(ISP_SCRIPTS))
 PYTHON_SCRIPTS += $(ISP_BACKEND)
 
-.PHONY: all install clean uninstall install-isp-scripts install-gdb-scripts install-runtime
+.PHONY: all install clean uninstall install-isp-scripts install-gdb-scripts install-runtime install-sources
 all: $(ISP_SCRIPTS)
 
-install: install-runtime install-isp-scripts install-gdb-scripts install-modules $(VENV_DONE)
+install: install-runtime install-isp-scripts install-gdb-scripts install-modules install-sources $(VENV_DONE)
 
 install-runtime:
 	mkdir -p $(POLICY_DIR)
@@ -62,6 +65,12 @@ install-gdb-scripts: $(GDB_SCRIPTS)
 install-modules: $(MODULES)
 	mkdir -p $(MODULE_DIR)
 	install $(MODULES) $(MODULE_DIR)
+
+$(SOURCES:%=$(ISP_PREFIX)/sources/%): $(ISP_PREFIX)/sources/%: $(HOPE_SRC)/%
+	mkdir -p $(ISP_PREFIX)/sources
+	rsync -av --exclude=".*" $^ $(ISP_PREFIX)/sources
+
+install-sources: $(ISP_PREFIX) $(SOURCES:%=$(ISP_PREFIX)/sources/%)
 
 install-sel4-template:
 	if [ ! -d $(ISP_PREFIX)/hope-seL4-app-template ]; then \

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -1,6 +1,5 @@
 include ../venv.mk
 
-HOPE_SRC_SYMLINK = $(ISP_PREFIX)/sources
 POLICY_DIR = $(ISP_PREFIX)/policies/
 BIN_DIR = $(ISP_PREFIX)/bin/
 GDB_DIR = $(ISP_PREFIX)/gdb-scripts/
@@ -42,10 +41,10 @@ INSTALLED_ISP_SCRIPTS := $(patsubst %,$(BIN_DIR)/%,$(ISP_SCRIPTS))
 PYTHON_SCRIPTS := $(patsubst %,%.py,$(ISP_SCRIPTS))
 PYTHON_SCRIPTS += $(ISP_BACKEND)
 
-.PHONY: all install clean uninstall symlink install-isp-scripts install-gdb-scripts install-runtime
+.PHONY: all install clean uninstall install-isp-scripts install-gdb-scripts install-runtime
 all: $(ISP_SCRIPTS)
 
-install: install-runtime install-isp-scripts install-gdb-scripts install-modules $(VENV_DONE) $(HOPE_SRC_SYMLINK)
+install: install-runtime install-isp-scripts install-gdb-scripts install-modules $(VENV_DONE)
 
 install-runtime:
 	mkdir -p $(POLICY_DIR)
@@ -85,18 +84,12 @@ install-stock-tools:
             fi
         endif
 
-symlink: $(HOPE_SRC_SYMLINK)
-
 $(ISP_SCRIPTS): %: %.py
 	printf '#!/bin/sh\n$(VENV) python $(RUNTIME_DIR)/$< "$$@"' > $@
 	chmod +x $@
-
-$(HOPE_SRC_SYMLINK):
-	ln -s $(HOPE_SRC) $@
 
 clean:
 	rm -rf $(ISP_SCRIPTS) *.pyc *.spec build/
 
 uninstall:
 	rm -rf $(INSTALLED_ISP_SCRIPTS) $(GDB_DIR) $(POLICY_DIR) $(RUNTIME_DIR) $(MODULE_DIR) $(VENV_DIR)
-	rm -f $(HOPE_SRC_SYMLINK)

--- a/runtime/isp_run_app.py
+++ b/runtime/isp_run_app.py
@@ -209,16 +209,6 @@ def main():
         logger.info("Using a stock simulator or runtime, setting policy to 'none'")
         policies = ["none"]
 
-    # use exiting policy directory if -p arg refers to path
-    if (len(policies) == 1 and 
-        "/" in args.policies[0] and
-        os.path.isdir(policies[0])):
-        policy_dir = os.path.abspath(policies[0])
-        policy_name = os.path.basename(policy_dir)
-    else:
-        policy_name = isp_utils.getPolicyFullName(policies, args.global_policies, args.policy_debug)
-        policy_dir = os.path.join(isp_prefix, "policies", policy_name)
-
     pex_path = args.pex
     if not pex_path:
         pex_path = sim_module.defaultPexPath(policy_name, arch, args.extra)
@@ -239,6 +229,16 @@ def main():
 
     isp_utils.removeIfExists(run_dir)
     isp_utils.doMkDir(run_dir)
+
+    # use exiting policy directory if -p arg refers to path
+    if (len(policies) == 1 and 
+        "/" in args.policies[0] and
+        os.path.isdir(policies[0])):
+        policy_dir = os.path.abspath(policies[0])
+        policy_name = os.path.basename(policy_dir)
+    else:
+        policy_name = isp_utils.getPolicyFullName(policies, args.global_policies, args.policy_debug)
+        policy_dir = os.path.join(run_dir, policy_name)
 
     if "stock_" not in args.runtime and use_validator == True:
         if not os.path.isdir(policy_dir):

--- a/runtime/isp_run_app.py
+++ b/runtime/isp_run_app.py
@@ -209,14 +209,18 @@ def main():
         logger.info("Using a stock simulator or runtime, setting policy to 'none'")
         policies = ["none"]
 
+    # use exiting policy directory if -p arg refers to path
+    if (len(policies) == 1 and  "/" in args.policies[0] and os.path.isdir(policies[0])):
+        policy_name = os.path.basename(policy_dir)
+    else:
+        policy_name = isp_utils.getPolicyFullName(policies, args.global_policies, args.policy_debug)
+
     args.exe_path = os.path.realpath(args.exe_path)
     exe_name = os.path.basename(args.exe_path)
-    run_dir = os.path.join(output_dir,
-                           "isp-run-{}-{}".format(exe_name, policy_name))
+    run_dir = os.path.join(output_dir, "isp-run-{}-{}".format(exe_name, policy_name))
 
     if args.rule_cache_name != "":
-        run_dir = run_dir + "-{}-{}".format(args.rule_cache_name,
-                                            args.rule_cache_size)
+        run_dir = run_dir + "-{}-{}".format(args.rule_cache_name, args.rule_cache_size)
 
     if args.suffix:
         run_dir = run_dir + "-" + args.suffix
@@ -225,13 +229,9 @@ def main():
     isp_utils.doMkDir(run_dir)
 
     # use exiting policy directory if -p arg refers to path
-    if (len(policies) == 1 and 
-        "/" in args.policies[0] and
-        os.path.isdir(policies[0])):
+    if (len(policies) == 1 and  "/" in args.policies[0] and os.path.isdir(policies[0])):
         policy_dir = os.path.abspath(policies[0])
-        policy_name = os.path.basename(policy_dir)
     else:
-        policy_name = isp_utils.getPolicyFullName(policies, args.global_policies, args.policy_debug)
         policy_dir = os.path.join(run_dir, policy_name)
 
     pex_path = args.pex

--- a/runtime/isp_run_app.py
+++ b/runtime/isp_run_app.py
@@ -11,6 +11,7 @@ import subprocess
 isp_prefix = isp_utils.getIspPrefix()
 sys.path.append(os.path.join(isp_prefix, "runtime", "modules"))
 sim_module = None
+import isp_pex_kernel
 
 logger = logging.getLogger()
 
@@ -236,7 +237,7 @@ def main():
 
     pex_path = args.pex
     if not pex_path:
-        pex_path = os.path.join(run_dir, "pex-kernel")
+        pex_path = os.path.join(run_dir, os.path.basename(sim_module.defaultPexPath(policy_name, arch, args.extra)))
     else:
         pex_path = os.path.realpath(args.pex)
 

--- a/runtime/isp_run_app.py
+++ b/runtime/isp_run_app.py
@@ -209,12 +209,6 @@ def main():
         logger.info("Using a stock simulator or runtime, setting policy to 'none'")
         policies = ["none"]
 
-    pex_path = args.pex
-    if not pex_path:
-        pex_path = sim_module.defaultPexPath(policy_name, arch, args.extra)
-    else:
-        pex_path = os.path.realpath(args.pex)
-
     args.exe_path = os.path.realpath(args.exe_path)
     exe_name = os.path.basename(args.exe_path)
     run_dir = os.path.join(output_dir,
@@ -239,6 +233,12 @@ def main():
     else:
         policy_name = isp_utils.getPolicyFullName(policies, args.global_policies, args.policy_debug)
         policy_dir = os.path.join(run_dir, policy_name)
+
+    pex_path = args.pex
+    if not pex_path:
+        pex_path = os.path.join(run_dir, "pex-kernel")
+    else:
+        pex_path = os.path.realpath(args.pex)
 
     if "stock_" not in args.runtime and use_validator == True:
         if not os.path.isdir(policy_dir):

--- a/runtime/isp_run_app.py
+++ b/runtime/isp_run_app.py
@@ -66,10 +66,10 @@ def compileMissingPex(policy_dir, pex_path, sim, arch, extra):
     return True
 
 
-def compileMissingPolicy(policies, global_policies, debug):
+def compileMissingPolicy(policies, global_policies, output_dir, debug):
     logger.info("Attempting to compile missing policy")
     args = ["isp_install_policy",
-            "-O", os.path.join(isp_prefix, "policies"),
+            "-O", output_dir,
             "-p"] + policies
 
     if global_policies:
@@ -242,7 +242,7 @@ def main():
 
     if "stock_" not in args.runtime and use_validator == True:
         if not os.path.isdir(policy_dir):
-            if compileMissingPolicy(policies, args.global_policies, args.policy_debug) is False:
+            if compileMissingPolicy(policies, args.global_policies, run_dir, args.policy_debug) is False:
                 logger.error("Failed to compile missing policy")
                 sys.exit(1)
 

--- a/runtime/modules/isp_iveia.py
+++ b/runtime/modules/isp_iveia.py
@@ -49,9 +49,6 @@ def installPex(policy_dir, output_dir, arch, extra):
     if not isp_utils.checkDependency(pex_kernel_source_dir, logger):
         return False
 
-    if not isp_utils.checkDependency(pex_firmware_source_dir, logger):
-        return False
-
     if not isp_pex_kernel.copyPexKernelSources(pex_kernel_source_dir, output_dir):
         return False
 

--- a/runtime/modules/isp_vcu118.py
+++ b/runtime/modules/isp_vcu118.py
@@ -49,9 +49,6 @@ def installPex(policy_dir, output_dir, arch, extra):
     if not isp_utils.checkDependency(pex_kernel_source_dir, logger):
         return False
 
-    if not isp_utils.checkDependency(pex_firmware_source_dir, logger):
-        return False
-
     if not isp_pex_kernel.copyPexKernelSources(pex_kernel_source_dir, output_dir):
         return False
 


### PR DESCRIPTION
Allow the tools to be installed in a global location not owned by the user running them.  To do this, all copying of data into or creation of files inside $ISP_PREFIX must be disabled, preferring to do all building within the output directory created by the tools.  Additionally, installation now no longer creates a "sources" symlink inside $ISP_PREFIX that points to the installer's hope-src directory, as the user running the tools may not have read or write privileges for the source location, preventing builds of the PEX kernel.  Instead, the "sources" symlink is now a directory with copies of hope-pex-kernel and hope-policies within it.

Some caveats to installing as root:
- `ISP_PREFIX` must be set and $PATH should contain `$ISP_PREFIX/bin` (this is standard, but worth mentioning)
- `make` in hope-src should be run using `sudo -E env PATH=$PATH`, or else `$ISP_PREFIX` and `$PATH` won't be preserved
- Running `make` in hope-src results in the creation of a .stack directory in $HOME owned by the person running `make`.  If this isn't the first time building hope-src, and the user building it is not the owner of this .stack directory, it needs to be manually deleted first or `stack` will refuse to run (even if the user building hope-src is root and the owner is not root)