### PR TITLE
Small build cleanups

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -46,7 +46,7 @@ INSTALLED_ISP_SCRIPTS := $(patsubst %,$(BIN_DIR)/%,$(ISP_SCRIPTS))
 PYTHON_SCRIPTS := $(patsubst %,%.py,$(ISP_SCRIPTS))
 PYTHON_SCRIPTS += $(ISP_BACKEND)
 
-.PHONY: all install clean uninstall install-isp-scripts install-gdb-scripts install-runtime install-sources
+.PHONY: all install clean uninstall install-isp-scripts install-gdb-scripts install-runtime install-sources $(SOURCES:%=$(ISP_PREFIX)/sources/%)
 all: $(ISP_SCRIPTS)
 
 install: install-runtime install-isp-scripts install-gdb-scripts install-modules install-sources $(VENV_DONE)
@@ -71,7 +71,7 @@ install-modules: $(MODULES)
 $(SOURCES:%=$(ISP_PREFIX)/sources/%): $(ISP_PREFIX)/sources/%: $(HOPE_SRC)/%
 	if [ -f "$^/Makefile.isp" ]; then $(MAKE) -C $^ -f Makefile.isp clean; fi
 	mkdir -p $(@D)
-	rsync -av --exclude=".*" $^ $(@D)
+	rsync -auv --exclude=".*" $^ $(@D)
 
 install-sources: $(ISP_PREFIX) $(SOURCES:%=$(ISP_PREFIX)/sources/%)
 

--- a/runtime/python-requirements.txt
+++ b/runtime/python-requirements.txt
@@ -1,5 +1,5 @@
 coloredlogs==10.0.0
 pyelftools==0.25
 pexpect-serial
-pyyaml==5.1.2
+pyyaml~=5.4.0
 yamlordereddictloader==0.4.0

--- a/runtime/templates/frtos_main.c
+++ b/runtime/templates/frtos_main.c
@@ -29,6 +29,10 @@
 #include <FreeRTOS.h>
 #include <task.h>
 
+
+/* ISP header */
+#include "isp_utils.h"
+
 /* Prototypes for the standard FreeRTOS callback/hook functions implemented
 within this file.  See https://www.freertos.org/a00016.html */
 void vApplicationMallocFailedHook( void );
@@ -36,10 +40,6 @@ void vApplicationIdleHook( void );
 void vApplicationStackOverflowHook( TaskHandle_t pxTask, char *pcTaskName );
 void vApplicationTickHook( void );
 
-/* Exits QEMU on failure conditions */
-void isp_test_device_fail(void);
-
-extern int isp_main(void);
 
 xTaskHandle xIspTask;
 
@@ -57,7 +57,8 @@ void vApplicationMallocFailedHook( void )
 	provide information on how the remaining heap might be fragmented). */
 	isp_test_device_fail();
 	taskDISABLE_INTERRUPTS();
-	for( ;; );
+	for( ;; )
+            ;
 }
 /*-----------------------------------------------------------*/
 
@@ -85,7 +86,8 @@ void vApplicationStackOverflowHook( TaskHandle_t pxTask, char *pcTaskName )
 	configCHECK_FOR_STACK_OVERFLOW is defined to 1 or 2.  This hook
 	function is called if a stack overflow is detected. */
 	taskDISABLE_INTERRUPTS();
-	for( ;; );
+	for( ;; )
+            ;
 }
 /*-----------------------------------------------------------*/
 
@@ -115,7 +117,8 @@ void isp_main_task(void *argument)
 
   t_printf("\nMain task has completed with code: 0x%08x\n", result);
 
-  for( ;; );
+  for( ;; )
+      ;
 
   // this may need changes to portable layer
   vTaskEndScheduler();
@@ -131,6 +134,7 @@ int main(void)
 
 	vTaskStartScheduler();
 
-	for( ;; );
+	for( ;; )
+            ;
   return 0;
 }

--- a/runtime/templates/isp_utils.h
+++ b/runtime/templates/isp_utils.h
@@ -7,5 +7,8 @@ int t_printf(const char *s, ...);
 int isp_main(void);
 uint64_t isp_get_cycle_count(uint32_t *result_hi, uint32_t *result_lo);
 uint32_t isp_get_time_usec(void);
+void isp_test_device_pass(void);
+void isp_test_device_fail(void);
+uint32_t isp_get_timer_freq(void);
 
 #endif // ISP_UTILS_H


### PR DESCRIPTION
Reinstall sources everytime `make` is run from `hope-src`. Using rsync should keep it from doing too much extraneous copying. Without something like this, policy modifications would not get updated in $ISP_PREFIX/sources, and thus would be ignored without a full `make distclean`.

The other changes reduce the warnings when compiling a test.