### PR TITLE
C++ Tagging Tools

### DIFF
--- a/runtime/isp_run_app.py
+++ b/runtime/isp_run_app.py
@@ -109,9 +109,6 @@ def main():
     parser.add_argument("-r", "--runtime", type=str, default="bare", help='''
     Currently supported: frtos, sel4, bare (bare metal) (default), stock_frtos, stock_sel4, stock_bare
     ''')
-    parser.add_argument("-a", "--arch", type=str, help='''
-    Architecture of executable. Currently supported: {}. Autodetect by default
-    '''.format(isp_utils.supportedArchs))
     parser.add_argument("-o", "--output", type=str, default="", help='''
     Location of simulator output directory. Contains supporting files and
     runtime logs.
@@ -184,15 +181,12 @@ def main():
         logger.error("Invalid choice of runtime. Valid choices: frtos, sel4, bare, stock_frtos, stock_sel4, stock_bare")
         return
 
-    if not args.arch:
-        arch = isp_utils.getArch(args.exe_path)
-        if not arch:
-            logger.error("Invalid choice of architecture. Valid choices: {}".format(isp_utils.supportedArchs))
-            return
+    arch = isp_utils.getArch(args.exe_path)
+    if not arch:
+        logger.error("Invalid choice of architecture. Valid choices: {}".format(isp_utils.supportedArchs))
+        return
 
-        logger.debug("Executable has architecture {}".format(arch))
-    else:
-        arch = args.arch
+    logger.debug("Executable has architecture {}".format(arch))
 
     if args.rule_cache_name not in ["", "finite", "infinite", "dmhc"]:
         logger.error("Invalid choice of rule cache name. Valid choices: finite, infinite, dmhc")

--- a/runtime/isp_utils.py
+++ b/runtime/isp_utils.py
@@ -88,16 +88,14 @@ def generateTagInfo(exe_path, run_dir, policy_dir, soc_cfg=None, arch=None):
     exe_name = os.path.basename(exe_path)
     doMkDir(os.path.join(run_dir, "bininfo"))
     args = ["gen_tag_info",
-            "-d", policy_dir,
-            "-t", os.path.join(run_dir, "bininfo", exe_name + ".taginfo"),
-            "-b", exe_path,
-            "-e", os.path.join(policy_dir, "policy_entities.yml"),
+            "--policy_dir", policy_dir,
+            "--tag_file", os.path.join(run_dir, "bininfo", exe_name + ".taginfo"),
+            "--bin", exe_path,
+            "--entities", os.path.join(policy_dir, "policy_entities.yml"),
             os.path.join(policy_dir, "composite_entities.yml"),
             os.path.join(run_dir, exe_name + ".entities.yml")]
     if soc_cfg is not None:
-        args += ["-s", soc_cfg]
-    if arch is not None:
-        args += ["--arch", arch]
+        args += ["--soc_file", soc_cfg]
 
     with open(os.path.join(run_dir, "inits.log"), "w+") as initlog:
         subprocess.Popen(args, stdout=initlog,


### PR DESCRIPTION
The C++ version of the tagging tools doesn't have a `--arch` parameter, so `isp_run_app` had to be updated to not use it.