### PR TITLE
Small improvements to runtime scripts

### DIFF
--- a/runtime/isp_run_app.py
+++ b/runtime/isp_run_app.py
@@ -226,7 +226,7 @@ def main():
     isp_utils.removeIfExists(run_dir)
     isp_utils.doMkDir(run_dir)
     logger.addHandler( logging.FileHandler("{0}/{1}.log".format(run_dir, "isp_run_app")))
-    logger.info("isp_run_app called with 'isp_run_app {}'".format(' '.join([arg for arg in sys.argv])))
+    logger.info("isp_run_app called with 'isp_run_app {}'".format(' '.join([arg for arg in sys.argv[1:]])))
 
     pex_path = args.pex
     if not pex_path:

--- a/runtime/modules/isp_vcu118.py
+++ b/runtime/modules/isp_vcu118.py
@@ -139,8 +139,14 @@ def program_fpga(bit_file, ltx_file, board, log_file):
                                 stdout=vivado_log, stderr=subprocess.STDOUT)
 
     # These processes will fail if vivado actually did its cleanup. That's fine.
-    cleanup_tmp_files = ["rm", "-f", "/tmp/digilent-adept2-*"]
-    subprocess.call(cleanup_tmp_files, stdout=vivado_log, stderr=subprocess.STDOUT)
+    logger.info("Running vivado cleanup. These commands failing likely means vivado did its own cleanup")
+
+    proc_res = subprocess.Popen("rm -f /tmp/digilent-adept2-*", shell=True, stderr=subprocess.STDOUT)
+    proc_res.wait()
+    logger.info(f"{(proc_res.args)} returned {proc_res.returncode}, with output:\n{proc_res.stdout}")
+
+    proc_res = subprocess.run(["killall", "hw_server", "cs_server"], stderr=subprocess.STDOUT)
+    logger.info(f"{(proc_res.args)} returned {proc_res.returncode}, with output:\n{proc_res.stdout}")
 
     vivado_log.close()
 


### PR DESCRIPTION
* Fix the command line printed when isp_run_app logs its command line (it was duplicating isp_run_app at the beginning)
* Do a better (though likely still incomplete) job of cleaning up after vivado